### PR TITLE
fix: typo in README.md in main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ npm run screen-semaphore
 Or in annother terminal launch a HTTP server to serve the zk-SNARK content:
 ```bash
 # Assuming you are in mixer/
-npm run semahpore
+npm run semaphore
 ```
 
 #### Run the frontend


### PR DESCRIPTION
there is a typo here in the README.md

```bash
# Assuming you are in mixer/
npm run semahpore
```

this commit changed `semahpore` to `semaphore`